### PR TITLE
Snyk auto fix

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1415,20 +1415,20 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.15.0"
+version = "3.19.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
-    {file = "zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b"},
+    {file = "zipp-3.19.1-py3-none-any.whl", hash = "sha256:2828e64edb5386ea6a52e7ba7cdb17bb30a73a858f5eb6eb93d8d36f5ea26091"},
+    {file = "zipp-3.19.1.tar.gz", hash = "sha256:35427f6d5594f4acf82d25541438348c26736fa9b3afa2754bcd63cdb99d8e8f"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "333273f975e6ff6a5dfd21e1d4917218dbb1e376fe718a3c20af3367764bcd2a"
+content-hash = "15765f6804a7e5c1cbdceb9ec2c49044c1a9be837fe72cd149f6122d0bd850d9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ requests = "2.32.3"
 certifi = "2024.7.4"
 urllib3 = "1.26.19"
 idna = "3.7"
+zipp = "3.19.1"
 
 [tool.poetry.dev-dependencies]
 prospector = { extras = ["with_mypy", "with_bandit", "with_pyroma"], version = "1.9.0" }


### PR DESCRIPTION
⠋ Running `snyk test` for /home/runner/work/jsonschema-validator/jsonschema-validator
► Running `snyk test` for /home/runner/work/jsonschema-validator/jsonschema-validator
- Looking for supported Python items

✔ Looking for supported Python items
- Looking for supported Python items

✔ Looking for supported Python items
⠋ Processing 1 pyproject.toml items⠋ Processing 2 requirements.txt items✔ Processed 2 requirements.txt items
- Checking poetry version
⚠️ Could not detect poetry version, proceeding anyway. Some operations may fail.
- Fixing pyproject.toml 1/1
✔ Processed 1 pyproject.toml items
✔ Done

Successful fixes:

  pyproject.toml
  ✔ Pinned zipp from 3.15.0 to 3.19.1

Summary:

  1 items were successfully fixed

  2 issues: 1 Medium | 1 Low
  1 issues are fixable
  1 issues were successfully fixed