### PR TITLE
Pin mheap/json-schema-spell-checker to version v2.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,7 +125,7 @@ repos:
             |\.github/publish\.yaml
           )$
   - repo: https://github.com/mheap/json-schema-spell-checker
-    rev: main
+    rev: v2.3.0
     hooks:
       - id: json-schema-spell-checker
         files: ^tests/schema\.json$


### PR DESCRIPTION
Pin the pre-commit hook `mheap/json-schema-spell-checker` from `main` to the tagged release `v2.3.0` for reproducible checks.