### PR TITLE
Replace --die-on-tool-error by --direct-tool-stdout in prospector

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,7 +89,7 @@ repos:
       - id: prospector
         args:
           - --profile=utils:pre-commit
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=.prospector.yaml
         additional_dependencies:
@@ -109,7 +109,7 @@ repos:
           )
       - id: prospector
         args:
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=utils:tests
           - --profile=utils:pre-commit

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help: ## Display this help message
 
 .PHONY: prospector
 prospector: .poetry.timestamps # Run Prospector check
-	poetry run prospector --output=pylint --die-on-tool-error
+	poetry run prospector --output=pylint --direct-tool-stdout
 
 .PHONY: pyprest
 pytest: .poetry.timestamps # Run the unit tests


### PR DESCRIPTION
Prospector --die-on-tool-error is replaced by --direct-tool-stdout.